### PR TITLE
Added service provider for java.sql.Driver

### DIFF
--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+io.opentracing.contrib.jdbc.TracingDriver


### PR DESCRIPTION
This file is required for auto detection, like on Wildfly and Wildfly Swam included.