### PR TITLE
Add MariaDB URL Parser to List of ConnectionInfo Parsers

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/parser/MariadbURLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/MariadbURLParser.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jdbc.parser;
+
+import io.opentracing.contrib.jdbc.ConnectionInfo;
+
+public class MariadbURLParser extends MysqlURLParser {
+
+  protected String dbType() {
+    return "mariadb";
+  }
+}

--- a/src/main/java/io/opentracing/contrib/jdbc/parser/MysqlURLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/MysqlURLParser.java
@@ -18,7 +18,10 @@ import io.opentracing.contrib.jdbc.ConnectionInfo;
 public class MysqlURLParser extends AbstractURLParser {
 
   private static final int DEFAULT_PORT = 3306;
-  private static final String DB_TYPE = "mysql";
+
+  protected String dbType() {
+    return "mysql";
+  }
 
   @Override
   protected URLLocation fetchDatabaseHostsIndexRange(String url) {
@@ -74,16 +77,16 @@ public class MysqlURLParser extends AbstractURLParser {
           sb.append(host + ",");
         }
       }
-      return new ConnectionInfo.Builder(sb.toString()).dbType(DB_TYPE)
+      return new ConnectionInfo.Builder(sb.toString()).dbType(dbType())
           .dbInstance(fetchDatabaseNameFromURL(url)).build();
     } else {
       String[] hostAndPort = hostSegment[0].split(":");
       if (hostAndPort.length != 1) {
         return new ConnectionInfo.Builder(hostAndPort[0], Integer.valueOf(hostAndPort[1]))
-            .dbType(DB_TYPE).dbInstance(fetchDatabaseNameFromURL(url, location.endIndex())).build();
+            .dbType(dbType()).dbInstance(fetchDatabaseNameFromURL(url, location.endIndex())).build();
       } else {
 
-        return new ConnectionInfo.Builder(hostAndPort[0], DEFAULT_PORT).dbType(DB_TYPE)
+        return new ConnectionInfo.Builder(hostAndPort[0], DEFAULT_PORT).dbType(dbType())
             .dbInstance(fetchDatabaseNameFromURL(url, location.endIndex())).build();
       }
     }

--- a/src/main/java/io/opentracing/contrib/jdbc/parser/URLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/URLParser.java
@@ -26,6 +26,7 @@ public class URLParser {
   private static final String ORACLE_JDBC_URL_PREFIX = "jdbc:oracle";
   private static final String H2_JDBC_URL_PREFIX = "jdbc:h2";
   private static final String POSTGRESQL_JDBC_URL_PREFIX = "jdbc:postgresql";
+  private static final String MARIADB_JDBC_URL_PREFIX = "jdbc:mariadb";
   private static final Map<String, ConnectionURLParser> parserRegister = new LinkedHashMap<>();
 
   static {
@@ -34,6 +35,7 @@ public class URLParser {
     parserRegister.put(ORACLE_JDBC_URL_PREFIX, new OracleURLParser());
     parserRegister.put(H2_JDBC_URL_PREFIX, new H2URLParser());
     parserRegister.put(POSTGRESQL_JDBC_URL_PREFIX, new PostgreSQLURLParser());
+    parserRegister.put(MARIADB_JDBC_URL_PREFIX, new MariadbURLParser());
   }
 
   /**


### PR DESCRIPTION
**Problem**
When using MariaDB url with this library, the `ConnectionInfo` always shows up as [`UNKNOWN_CONNECTION_INFO`](https://github.com/opentracing-contrib/java-jdbc/blob/30745b7608ca67100a286c8d1a0a6e016b77fb90/src/main/java/io/opentracing/contrib/jdbc/ConnectionInfo.java#L18).

**Solution**
This adds a `MariadbURLParser` class to the map of registered url parsers. The implementation of this parser is effectively piggybacking off the implementation of the `MysqlURLParser` because the
`maria` URLs are built to be compatible with `mysql` URLs. the [connecting string structure](https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings):

``` 
jdbc:(mysql|mariadb):[replication:|failover:|sequential:|aurora:]//<hostDescription>[,<hostDescription>...]/[database][?<key1>=<value1>[&<key2>=<value2>]] 
```