### PR TITLE
Interceptor Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .idea/
-*.iml
+.metadata/
+.recommenders/
+.settings/
 target/
+*.iml
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.opentracing.contrib</groupId>
   <artifactId>opentracing-jdbc</artifactId>
-  <version>0.1.9-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>OpenTracing Instrumentation for JDBC API</description>
@@ -55,7 +55,8 @@
   </issueManagement>
 
   <properties>
-    <java.version>1.7</java.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
@@ -132,15 +133,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>

--- a/src/test/java/io/opentracing/contrib/jdbc/SpringTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/SpringTest.java
@@ -195,11 +195,11 @@ public class SpringTest {
     checkNoEmptyTags(finishedSpans);
   }
 
-  private BasicDataSource getDataSource(boolean traceWithActiveSpanOnly) {
+  private static BasicDataSource getDataSource(boolean traceWithActiveSpanOnly) {
     return getDataSource(traceWithActiveSpanOnly, new ArrayList<String>());
   }
 
-  private BasicDataSource getDataSource(boolean traceWithActiveSpanOnly, List<String> ignored) {
+  private static BasicDataSource getDataSource(boolean traceWithActiveSpanOnly, List<String> ignored) {
 
     String ignoreForTracing = TestUtil.buildIgnoredString(ignored);
 


### PR DESCRIPTION
This PR adds "interceptor mode" to the `TracingDriver`. The "interceptor mode" is described in the [README.md](https://github.com/SevaSafris/java-jdbc/#interceptor).

The "interceptor mode" behavior is deactivated by default, which means that the `TracingDriver` works in the same way as before. Only by calling `TracingDriver.setInterceptorMode(true)` will the "interceptor mode" be activated.

A few other modifications are a part of this PR:

1. Add `TracingDriver.load()`, which returns the `TracerDriver` singleton instance. The existence of this method will greatly simplify [this code](https://github.com/opentracing-contrib/java-specialagent/blob/master/rules/jdbc/src/main/java/io/opentracing/contrib/specialagent/jdbc/JdbcAgentIntercept.java#L54-L62), which obtains the singleton instance via the `DriverManager`.
1. Lower the class version to jdk1.7.
1. Add assertion to validate that the expected `Driver` is returned from `DriverManager`: `JdbcTest.assertGetDriver(connection)`.

I have bumped the version of the `java-jdbc` module to `0.2.0`.