### PR TITLE
Fix spelling in error message to make it easier to debug

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/parser/URLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/URLParser.java
@@ -53,7 +53,7 @@ public class URLParser {
     try {
       return parser.parse(url);
     } catch (Exception e) {
-      log.log(Level.WARNING, "error occurs when paring jdbc url");
+      log.log(Level.WARNING, "error occurs when parsing jdbc url");
     }
     return ConnectionInfo.UNKNOWN_CONNECTION_INFO;
   }


### PR DESCRIPTION
### What?
Fix spelling in error message: `paring` -> `parsing`

### Why?
The spelling error in this message made it more difficult for my team to track down the underlying problem, so I'd like to fix it.