### PR TITLE
Parse mysql url without db name or query string (#54)

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/parser/MysqlURLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/MysqlURLParser.java
@@ -25,12 +25,17 @@ public class MysqlURLParser extends AbstractURLParser {
 
   @Override
   protected URLLocation fetchDatabaseHostsIndexRange(String url) {
-    int hostLabelStartIndex = url.indexOf("//");
-    int hostLabelEndIndex = url.indexOf("/", hostLabelStartIndex + 2);
+    int hostLabelStartIndex = url.indexOf("//") + 2;
+    int hostLabelEndIndex = url.indexOf("/", hostLabelStartIndex);
     if (hostLabelEndIndex == -1) {
-      hostLabelEndIndex = url.indexOf("?", hostLabelStartIndex + 2);
+      int queryStringStartIndex = url.indexOf("?", hostLabelStartIndex);
+      if( queryStringStartIndex == -1 ){
+        hostLabelEndIndex = url.length();
+      } else {
+        hostLabelEndIndex = queryStringStartIndex;
+      }
     }
-    return new URLLocation(hostLabelStartIndex + 2, hostLabelEndIndex);
+    return new URLLocation(hostLabelStartIndex, hostLabelEndIndex);
   }
 
   protected String fetchDatabaseNameFromURL(String url, int startSize) {

--- a/src/test/java/io/opentracing/contrib/jdbc/parser/URLParserTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/parser/URLParserTest.java
@@ -44,6 +44,14 @@ public class URLParserTest {
   }
 
   @Test
+  public void testParseMysqlURLWithoutExplicitDBOrQueryString(){
+    ConnectionInfo connectionInfo = URLParser.parser("jdbc:mysql://primaryhost");
+    assertEquals(MYSQL, connectionInfo.getDbType());
+    assertEquals("", connectionInfo.getDbInstance());
+    assertEquals("primaryhost:3306", connectionInfo.getDbPeer());
+  }
+
+  @Test
   public void testParseMysqlJDBCURLWithHostAndPort() {
     ConnectionInfo connectionInfo = URLParser
         .parser("jdbc:mysql//primaryhost:3307/test?profileSQL=true");
@@ -234,7 +242,7 @@ public class URLParserTest {
   @Test
   public void testNoParserFound() {
     ConnectionInfo connectionInfo = URLParser
-        .parser("jdbc:unkown_type//primaryhost?profileSQL=true");
+        .parser("jdbc:unknown_type//primaryhost?profileSQL=true");
     assertEquals(ConnectionInfo.UNKNOWN_CONNECTION_INFO, connectionInfo);
   }
 }


### PR DESCRIPTION
This handles a mysql jdbc url that does not explicitly name a DB, and does not have a query string.

e.g. jdbc:mysql://somehost