### PR TITLE
Tracing javax.sql.DataSource implementation

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/TracingDataSource.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/TracingDataSource.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jdbc;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.common.WrapperProxy;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static io.opentracing.contrib.jdbc.JdbcTracingUtils.buildSpan;
+
+public class TracingDataSource implements DataSource {
+    private static final boolean DEFAULT_WITH_ACTIVE_SPAN_ONLY = false;
+    private static final Set<String> DEFAULT_IGNORED_STATEMENTS = Collections.emptySet();
+
+    private final Tracer tracer;
+    private final DataSource underlying;
+    private final ConnectionInfo connectionInfo;
+    private final boolean withActiveSpanOnly;
+    private final Set<String> ignoreStatements;
+
+    public TracingDataSource(final Tracer tracer,
+                             final DataSource underlying)
+    {
+        this(tracer, underlying, ConnectionInfo.UNKNOWN_CONNECTION_INFO, DEFAULT_WITH_ACTIVE_SPAN_ONLY,
+                DEFAULT_IGNORED_STATEMENTS);
+    }
+
+    public TracingDataSource(final Tracer tracer,
+                             final DataSource underlying,
+                             final ConnectionInfo connectionInfo,
+                             final boolean withActiveSpanOnly,
+                             final Set<String> ignoreStatements)
+    {
+        this.tracer = tracer;
+        this.underlying = underlying;
+        this.connectionInfo = connectionInfo;
+        this.withActiveSpanOnly = withActiveSpanOnly;
+        this.ignoreStatements = ignoreStatements;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        final Span span = buildSpan("AcquireConnection", "", connectionInfo, withActiveSpanOnly,
+                ignoreStatements, tracer);
+        final Connection connection;
+        try (Scope ignored = tracer.activateSpan(span)) {
+            connection = underlying.getConnection();
+        } catch (Exception e) {
+            JdbcTracingUtils.onError(e, span);
+            throw e;
+        } finally {
+            span.finish();
+        }
+
+        return WrapperProxy
+                .wrap(connection, new TracingConnection(connection, connectionInfo, withActiveSpanOnly,
+                        ignoreStatements, tracer));
+    }
+
+    @Override
+    public Connection getConnection(final String username, final String password) throws SQLException {
+        final Span span = buildSpan("AcquireConnection", "", connectionInfo, withActiveSpanOnly,
+                ignoreStatements, tracer);
+        final Connection connection;
+        try (Scope ignored = tracer.activateSpan(span)) {
+            connection = underlying.getConnection(username, password);
+        } catch (Exception e) {
+            JdbcTracingUtils.onError(e, span);
+            throw e;
+        } finally {
+            span.finish();
+        }
+
+        return WrapperProxy
+                .wrap(connection, new TracingConnection(connection, connectionInfo, withActiveSpanOnly,
+                        ignoreStatements, tracer));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return underlying.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(final PrintWriter out) throws SQLException {
+        underlying.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(final int seconds) throws SQLException {
+        underlying.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return underlying.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return underlying.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(final Class<T> iface) throws SQLException {
+        return underlying.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(final Class<?> iface) throws SQLException {
+        return underlying.isWrapperFor(iface);
+    }
+}

--- a/src/test/java/io/opentracing/contrib/jdbc/TracingDataSourceTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/TracingDataSourceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jdbc;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+public class TracingDataSourceTest {
+    @Test
+    public void traces_acquiring_connection() throws SQLException {
+        final BasicDataSource dataSource = getDataSource();
+        final MockTracer mockTracer = new MockTracer();
+        final TracingDataSource tracingDataSource = new TracingDataSource(mockTracer, dataSource);
+
+        try (final Connection connection = tracingDataSource.getConnection()) {
+            assertFalse(mockTracer.finishedSpans().isEmpty());
+        }
+    }
+
+    @Test
+    public void sets_error() {
+        final BasicDataSource dataSource = getErroneousDataSource();
+        final MockTracer mockTracer = new MockTracer();
+        final TracingDataSource tracingDataSource = new TracingDataSource(mockTracer, dataSource);
+
+        try (final Connection connection = tracingDataSource.getConnection()) {
+            assertNull("Get connection", connection);
+        }
+        catch (SQLException ignored) {}
+
+        assertFalse(mockTracer.finishedSpans().isEmpty());
+        MockSpan finishedSpan = mockTracer.finishedSpans().get(0);
+        assertTrue("Span contains error tag", finishedSpan.tags().containsKey(Tags.ERROR.getKey()));
+    }
+
+    @Test(expected = SQLException.class)
+    public void rethrows_any_error() throws SQLException {
+        final BasicDataSource dataSource = getErroneousDataSource();
+        final MockTracer mockTracer = new MockTracer();
+        final TracingDataSource tracingDataSource = new TracingDataSource(mockTracer, dataSource);
+
+        tracingDataSource.getConnection();
+    }
+
+    private static BasicDataSource getDataSource() {
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setUrl("jdbc:h2:mem:dataSourceTest");
+        return dataSource;
+    }
+
+    private static BasicDataSource getErroneousDataSource() {
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setUrl("jdbc:invalid");
+        return dataSource;
+    }
+}


### PR DESCRIPTION
Allows you to easily add tracing to an existing javax.sql.DataSource without having to modify the driver URL.