### PR TITLE
Make interceptor mode of TracingDriver work with other wrapper drivers

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java
@@ -150,16 +150,17 @@ public class TracingDriver implements Driver {
 
     final Set<String> ignoreStatements;
     final boolean withActiveSpanOnly;
-    if (acceptsURL(url)) {
-      withActiveSpanOnly = url.contains(WITH_ACTIVE_SPAN_ONLY);
-      ignoreStatements = extractIgnoredStatements(url);
-      url = extractRealUrl(url);
-    } else if (!interceptorMode) {
-      return null;
-    } else {
+    if (interceptorMode) {
       withActiveSpanOnly = TracingDriver.withActiveSpanOnly;
       ignoreStatements = TracingDriver.ignoreStatements;
+    } else if (acceptsURL(url)) {
+      withActiveSpanOnly = url.contains(WITH_ACTIVE_SPAN_ONLY);
+      ignoreStatements = extractIgnoredStatements(url);
+    } else {
+      return null;
     }
+
+    url = extractRealUrl(url);
 
     // find the real driver for the URL
     final Driver wrappedDriver = findDriver(url);
@@ -182,7 +183,10 @@ public class TracingDriver implements Driver {
 
   @Override
   public boolean acceptsURL(String url) throws SQLException {
-    return url != null && url.startsWith(getUrlPrefix());
+    return url != null && (
+        url.startsWith(getUrlPrefix()) ||
+        (interceptorMode && url.startsWith("jdbc:"))
+    );
   }
 
   @Override

--- a/src/test/java/io/opentracing/contrib/jdbc/JdbcTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/JdbcTest.java
@@ -26,16 +26,28 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Enumeration;
 import java.util.List;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JdbcTest {
-  public static void assertGetDriver(final Connection connection) throws SQLException {
+  private static void assertGetDriver(final Connection connection) throws SQLException {
     final String originalURL = connection.getMetaData().getURL();
-    final Driver driver = DriverManager.getDriver(originalURL);
+    final Driver driver = getUnderlyingDriver(originalURL);
     assertEquals("org.h2.Driver", driver.getClass().getName());
+  }
+
+  private static Driver getUnderlyingDriver(final String url) throws SQLException {
+    final Enumeration<Driver> enumeration = DriverManager.getDrivers();
+    while (enumeration.hasMoreElements()) {
+      final Driver driver = enumeration.nextElement();
+      if (driver.acceptsURL(url) && !(driver instanceof TracingDriver)) {
+        return driver;
+      }
+    }
+    return null;
   }
 
   private static final MockTracer mockTracer = new MockTracer();


### PR DESCRIPTION
## Problem

In the interceptor mode of`TracingDriver`, it is supposed to be able to trace JDBC connections without modifying the URL. However, this may not work in some cases. For instance, if another wrapper driver calls `Driver#acceptsURL` for each registered driver in order to find the underlying driver, it won't see `TracingDriver` unless the JDBC URL has been rewritten to have the `jdbc:tracing:` prefix.

## Solution

In interceptor mode, `TracingDriver#acceptsURL` should accept any JDBC URL. The user should not need to (and should not) modify the URL for the interceptor mode to work. Also, in interceptor mode, `TracingDriver` should not try to extract `withActiveSpanOnly` or `ignoreStatements` properties from the URL, as they should be set via `TracingDriver#setInterceptorProperty`.

Fixes opentracing-contrib/java-jdbc#68.