### PR TITLE
Make TracingDataSource implements AutoCloseable

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/TracingDataSource.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/TracingDataSource.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 
-public class TracingDataSource implements DataSource {
+public class TracingDataSource implements DataSource, AutoCloseable {
   private static final boolean DEFAULT_WITH_ACTIVE_SPAN_ONLY = false;
   private static final Set<String> DEFAULT_IGNORED_STATEMENTS = Collections.emptySet();
 
@@ -128,5 +128,12 @@ public class TracingDataSource implements DataSource {
   @Override
   public boolean isWrapperFor(final Class<?> iface) throws SQLException {
     return underlying.isWrapperFor(iface);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if(underlying instanceof AutoCloseable) {
+      ((AutoCloseable)underlying).close();
+    }
   }
 }


### PR DESCRIPTION
Container like spring ApplicationContext will close underlying DataSource automatically.
```
	@Bean
	public DataSource dataSource() {
		DataSource ds = createDataSource();
		if (tracingEnabled) {
			ds = new TracingDataSource(tracingConfiguration.getTracer(), ds);
			//the underlying ds will not be closed since it's not managed by spring now
		}
		return ds;
	}
```