### PR TITLE
Get underlying dataSource via unwrap method

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/TracingDataSource.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/TracingDataSource.java
@@ -56,6 +56,10 @@ public class TracingDataSource implements DataSource, AutoCloseable {
     this.ignoreStatements = ignoreStatements;
   }
 
+  public DataSource getUnderlying() {
+    return underlying;
+  }
+
   @Override
   public Connection getConnection() throws SQLException {
     final Span span = buildSpan("AcquireConnection", "", connectionInfo, withActiveSpanOnly,


### PR DESCRIPTION
Before this commit, there is no way to get underlying ds.
Is this or adding extra getter method better? WDYT @malafeev ?