### PR TITLE
Fix missing runnable.run()

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/JdbcTracingUtils.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/JdbcTracingUtils.java
@@ -62,6 +62,7 @@ class JdbcTracingUtils {
       Set<String> ignoreStatements,
       Tracer tracer) throws E {
     if (!TracingDriver.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
+      runnable.run();
       return;
     }
 


### PR DESCRIPTION
introduced by PR#96, connection is not closed if withActiveSpanOnly and no active span.