### PR TITLE
Improve regex for DB2 and AS400 URL Parser

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/parser/AS400URLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/AS400URLParser.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 public class AS400URLParser extends AbstractMatcherURLParser {
 
     private static final Pattern AS400_URL_PATTERN = Pattern
-        .compile("jdbc:as400:\\/\\/(?<host>[^\\/^;]+)(\\/(?<instance>[^;^\\/]*))?\\/?(;(?<options>.*))?");
+        .compile("jdbc:as400:\\/\\/(?<host>[^\\/;]+)(\\/(?<instance>[^;\\/]*))?\\/?(;(?<options>.*))?");
 
     private static final String AS400_TYPE = "as400";
 

--- a/src/main/java/io/opentracing/contrib/jdbc/parser/DB2URLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/DB2URLParser.java
@@ -26,7 +26,7 @@ public class DB2URLParser extends AbstractMatcherURLParser {
 
 
     private static final Pattern DB2_URL_PATTERN = Pattern
-        .compile("jdbc:db2:\\/\\/(?<host>[^:^\\/]+)(:(?<port>\\d+))?\\/(?<instance>[^\\?^:]+)(:(?<options>.*))?");
+        .compile("jdbc:db2:\\/\\/(?<host>[^:\\/]+)(:(?<port>\\d+))?\\/(?<instance>[^:]+)(:(?<options>.*))?");
 
     private static final String DB2_TYPE = "db2";
 


### PR DESCRIPTION
1. negate char `^` should be declared only once.
2. db2 only use `:` as separator no `?` [document](https://www.ibm.com/support/knowledgecenter/en/SSEPEK_11.0.0/java/src/tpc/imjcc_r0052342.html)

@oburgosm Would you take a look at this?