### PR TITLE
Fix database name parsing when a path URL query params contains a path

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/parser/PostgreSQLURLParser.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/parser/PostgreSQLURLParser.java
@@ -31,7 +31,9 @@ public class PostgreSQLURLParser extends AbstractURLParser {
 
   @Override
   protected URLLocation fetchDatabaseNameIndexRange(String url) {
-    int databaseStartTag = url.lastIndexOf("/");
+    int hostLabelStartIndex = url.indexOf("//");
+    int hostLabelEndIndex = url.indexOf("/", hostLabelStartIndex + 2);
+    int databaseStartTag = url.indexOf("/", hostLabelEndIndex);
     int databaseEndTag = url.indexOf("?", databaseStartTag);
     if (databaseEndTag == -1) {
       databaseEndTag = url.length();

--- a/src/test/java/io/opentracing/contrib/jdbc/parser/URLParserTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/parser/URLParserTest.java
@@ -260,6 +260,16 @@ public class URLParserTest {
   }
 
   @Test
+  public void testParsePostgresqlJDBCURLWithSSLCertPath() {
+    ConnectionInfo connectionInfo = URLParser
+        .parse("jdbc:postgresql//primaryhost:3307/test?sslmode=verify-full&sslrootcert=/some/path.pem");
+    assertEquals(POSTGRESQL, connectionInfo.getDbType());
+    assertEquals("test", connectionInfo.getDbInstance());
+    assertEquals("primaryhost:3307", connectionInfo.getDbPeer());
+    assertEquals("test[postgresql(primaryhost:3307)]", connectionInfo.getPeerService());
+  }
+
+  @Test
   public void testParsePostgresqlJDBCURLWithMultiHost() {
     ConnectionInfo connectionInfo = URLParser.parse(
         "jdbc:postgresql//primaryhost:3307,secondaryhost1,secondaryhost2/test?profileSQL=true");


### PR DESCRIPTION
Postgres allows the path to certificates to be specified among the URL query params, e.g. `jdbc:postgresql://host:port/dbname?sslmode=verify-full&sslrootcert=/some/path.pem`. Prior to this fix, the `db.instance` tag would be set to `path.pem` instead of `dbname`.

This change counts slashes from the left, rather than the right, when detecting the DB name.