### PR TITLE
Prevent TracingDriver registration when not in use

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/JdbcTracing.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/JdbcTracing.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jdbc;
+
+public class JdbcTracing {
+  private static boolean traceEnabled = true;
+
+  /**
+   * Sets the {@code traceEnabled} property to enable or disable traces.
+   *
+   * @param traceEnabled The {@code traceEnabled} value.
+   */
+  public static void setTraceEnabled(boolean traceEnabled) {
+    JdbcTracing.traceEnabled = traceEnabled;
+  }
+
+  public static boolean isTraceEnabled() {
+    return JdbcTracing.traceEnabled;
+  }
+}

--- a/src/main/java/io/opentracing/contrib/jdbc/JdbcTracingUtils.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/JdbcTracingUtils.java
@@ -47,7 +47,7 @@ class JdbcTracingUtils {
       boolean withActiveSpanOnly,
       Set<String> ignoreStatements,
       Tracer tracer) {
-    if (!TracingDriver.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
+    if (!JdbcTracing.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
       return NoopSpan.INSTANCE;
     } else if (ignoreStatements != null && ignoreStatements.contains(sql)) {
       return NoopSpan.INSTANCE;
@@ -69,7 +69,7 @@ class JdbcTracingUtils {
       boolean withActiveSpanOnly,
       Set<String> ignoreStatements,
       Tracer tracer) throws E {
-    if (!TracingDriver.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
+    if (!JdbcTracing.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
       runnable.run();
       return;
     }
@@ -97,7 +97,7 @@ class JdbcTracingUtils {
   boolean withActiveSpanOnly,
   Set<String> ignoreStatements,
   Tracer tracer) throws E {
-    if (!TracingDriver.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
+    if (!JdbcTracing.isTraceEnabled() || (withActiveSpanOnly && tracer.activeSpan() == null)) {
       return callable.call();
     }
 

--- a/src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java
@@ -91,19 +91,17 @@ public class TracingDriver implements Driver {
     }
   }
 
-  private static boolean traceEnabled = true;
-
   /**
    * Sets the {@code traceEnabled} property to enable or disable traces.
    *
    * @param traceEnabled The {@code traceEnabled} value.
    */
   public static void setTraceEnabled(boolean traceEnabled) {
-    TracingDriver.traceEnabled = traceEnabled;
+    JdbcTracing.setTraceEnabled(traceEnabled);
   }
 
   public static boolean isTraceEnabled() {
-    return TracingDriver.traceEnabled;
+    return JdbcTracing.isTraceEnabled();
   }
 
   private static boolean interceptorMode = false;


### PR DESCRIPTION
Pull request #70 caused issues since the driver will be registered and never de-register itself when not in use due to static references from JdbcTracingUtils