### PR TITLE
Fix tag key for excludeFastQueryThresholdMs

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/JdbcTracingUtils.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/JdbcTracingUtils.java
@@ -36,7 +36,7 @@ class JdbcTracingUtils {
   static final StringTag PEER_ADDRESS = new StringTag("peer.address");
 
   static final BooleanTag SLOW = new BooleanTag("slow");
-  static final IntTag PEER_SAMPLING = new IntTag("peer.sampling");
+  static final IntTag SAMPLING_PRIORITY = new IntTag("sampling.priority");
 
   static Span buildSpan(String operationName,
       String sql,
@@ -160,7 +160,7 @@ class JdbcTracingUtils {
     long completionTime = System.nanoTime() - startTime;
     if (JdbcTracing.getExcludeFastQueryThresholdMs() > 0 && completionTime < TimeUnit.MILLISECONDS
         .toNanos(JdbcTracing.getExcludeFastQueryThresholdMs())) {
-      PEER_SAMPLING.set(span, 0);
+      SAMPLING_PRIORITY.set(span, 0);
     }
     if (JdbcTracing.getSlowQueryThresholdMs() > 0 && completionTime > TimeUnit.MILLISECONDS
         .toNanos(JdbcTracing.getSlowQueryThresholdMs())) {

--- a/src/test/java/io/opentracing/contrib/jdbc/JdbcTracingUtilsTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/JdbcTracingUtilsTest.java
@@ -115,7 +115,7 @@ public class JdbcTracingUtilsTest {
     final List<MockSpan> finishedSpans = mockTracer.finishedSpans();
     assertEquals("Should have traced a query execution", 1, finishedSpans.size());
     final MockSpan fastQuerySpan = finishedSpans.get(0);
-    assertTrue("Span should be tagged with peer.sampling=0",
-        fastQuerySpan.tags().containsKey(JdbcTracingUtils.PEER_SAMPLING.getKey()));
+    assertTrue("Span should be tagged with sampling.priority=0",
+        fastQuerySpan.tags().containsKey(JdbcTracingUtils.SAMPLING_PRIORITY.getKey()));
   }
 }


### PR DESCRIPTION
Original PR #112 used the incorrect tag key, this PR corrects that. Any span tagged with `sampling.priority=0` will not be reported.