### PR TITLE
Potential fix for code scanning alert no. 7: Depending upon JCenter/Bintray as an artifact repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,12 +240,12 @@
 
   <distributionManagement>
     <repository>
-      <id>bintray</id>
-      <url>https://api.bintray.com/maven/opentracing/maven/opentracing-jdbc/;publish=1</url>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
     <snapshotRepository>
-      <id>jfrog-snapshots</id>
-      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
Potential fix for [https://github.com/opentracing-contrib/java-jdbc/security/code-scanning/7](https://github.com/opentracing-contrib/java-jdbc/security/code-scanning/7)

The correct fix is to replace deprecated Bintray/JFrog legacy endpoints in `distributionManagement` with a current canonical repository (typically Sonatype OSSRH for Maven Central publishing), while preserving build behavior otherwise.

In `pom.xml`, update the `<distributionManagement>` section (around lines 241–250):
- Change the release `<repository>` from Bintray to OSSRH staging deploy URL.
- Change the snapshot `<snapshotRepository>` from `oss.jfrog.org` (and HTTP) to OSSRH snapshots over HTTPS.
- Keep the structure and IDs consistent with common Maven deploy configuration (`ossrh`), without modifying unrelated plugins/profiles.

No new methods/imports/dependencies are required; this is purely POM configuration hardening.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact publishing destinations for release and snapshot builds to use Sonatype OSSRH.
  * Replaced retired Bintray and JFrog publishing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->