### PR TITLE
Fix dereferenced variable may be null

### DIFF
--- a/src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java
+++ b/src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java
@@ -71,14 +71,13 @@ public class TracingDriver implements Driver {
   public synchronized static void ensureRegisteredAsTheFirstDriver() {
     try {
       Enumeration<Driver> enumeration = DriverManager.getDrivers();
-      List<Driver> drivers = null;
+      List<Driver> drivers = new ArrayList<>();
       for (int i = 0; enumeration.hasMoreElements(); ++i) {
         Driver driver = enumeration.nextElement();
         if (i == 0) {
           if (driver == INSTANCE) {
             return;
           }
-          drivers = new ArrayList<>();
         }
         if (driver != INSTANCE) {
           drivers.add(driver);


### PR DESCRIPTION
Potential fix for [https://github.com/opentracing-contrib/java-jdbc/security/code-scanning/21](https://github.com/opentracing-contrib/java-jdbc/security/code-scanning/21)

General fix: avoid nullable collection variables that are iterated later; initialize them eagerly or guard iteration with a null check.

Best fix here (minimal behavior change): in `ensureRegisteredAsTheFirstDriver()` in `src/main/java/io/opentracing/contrib/jdbc/TracingDriver.java`, initialize `drivers` as an empty list at declaration and remove the delayed initialization inside `if (i == 0)`. This preserves existing logic while guaranteeing the loop at line 88 is always safe, including when no drivers are returned.

No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JDBC driver registration initialization to ensure consistent behavior when selecting the first registered driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->