### PR TITLE
Potential fix for code scanning alert no. 20: Potential database resource leak

### DIFF
--- a/src/test/java/io/opentracing/contrib/jdbc/JdbcTest.java
+++ b/src/test/java/io/opentracing/contrib/jdbc/JdbcTest.java
@@ -135,10 +135,11 @@ public class JdbcTest {
   public void testFailInterceptor() throws Exception {
     TracingDriver.setInterceptorMode(false);
     try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:jdbc")) {
-      Statement statement = connection.createStatement();
-      try {
-        statement.executeUpdate("CREATE TABLE employer (id INTEGER2)");
-      } catch (Exception ignore) {
+      try (Statement statement = connection.createStatement()) {
+        try {
+          statement.executeUpdate("CREATE TABLE employer (id INTEGER2)");
+        } catch (Exception ignore) {
+        }
       }
       assertGetDriver(connection);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/opentracing-contrib/java-jdbc/security/code-scanning/20](https://github.com/opentracing-contrib/java-jdbc/security/code-scanning/20)

Use try-with-resources for the `Statement` so it is always closed, even if `executeUpdate` throws.  
Best fix (without changing behavior): in `testFailInterceptor`, wrap `connection.createStatement()` in its own try-with-resources block and keep the existing inner `try/catch` around the invalid SQL execution so test semantics remain unchanged.

Edit file:
- `src/test/java/io/opentracing/contrib/jdbc/JdbcTest.java`
- Region around lines 137–144 (`testFailInterceptor`)

No new imports or dependencies are required since try-with-resources is a language feature and `Statement` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
